### PR TITLE
Add formatting option for upper case sequence data in TriSeq/TriFusion

### DIFF
--- a/trifusion/TriSeq.py
+++ b/trifusion/TriSeq.py
@@ -91,6 +91,7 @@ def main_parser(arg, alignment_list):
     outfile = arg.outfile
     interleave = arg.interleave
     model_phy = arg.model_phy
+    upper_case = arg.upper_case
     # outgroup_taxa = arg.outgroup_taxa
 
     # Defining output file name
@@ -288,7 +289,8 @@ def main_parser(arg, alignment_list):
                              ima2_params=arg.ima2_params,
                              partition_file=True,
                              use_charset=True,
-                             pbar=pbar)
+                             pbar=pbar,
+                             upper_case=upper_case)
 
 
 def get_args(arg_list=None, unittest=False):
@@ -435,6 +437,10 @@ def get_args(arg_list=None, unittest=False):
                             default=False, help="Specify this  option to "
                             "write output files in interleave format (currently"
                             " only supported for nexus files")
+    formatting.add_argument("-u", "--upper-case", dest="upper_case",
+                            action="store_const", const=True, default=False,
+                            help="Write sequence data in upper case (the"
+                                 "default is lower case)")
     formatting.add_argument("--ima2-params", dest="ima2_params", nargs=4,
                             help="Provide 4 additional arguments needed to "
                             "write the output in a format compliant with "

--- a/trifusion/app.py
+++ b/trifusion/app.py
@@ -439,7 +439,8 @@ class TriFusionApp(App):
                                       ("variation_filter", False),
                                       ("gcoder_file", False),
                                       ("consensus_file", False),
-                                      ("consensus_single", False)])
+                                      ("consensus_single", False),
+                                      ("upper_case", False)])
     """
     Dictionary mapping secondary options to a bool value. Active secondary
     options have a True value.

--- a/trifusion/data/resources/background_tasks.py
+++ b/trifusion/data/resources/background_tasks.py
@@ -879,7 +879,8 @@ def process_execution(aln_list, file_set_name, file_list, active_file_list,
                 ima2_params=ima2_params,
                 use_nexus_models=use_nexus_models,
                 ns_pipe=ns,
-                table_name=table_name)
+                table_name=table_name,
+                upper_case=secondary_options["upper_case"])
 
         except IOError as e:
             logging.exception(e)

--- a/trifusion/process/sequence.py
+++ b/trifusion/process/sequence.py
@@ -6273,6 +6273,7 @@ class AlignmentList(Base):
         table_name = kwargs.get("table_name", self.master_table)
         ns = kwargs.get("ns_pipe", None)
         pbar = kwargs.get("pbar", None)
+        upper_case = kwargs.get("upper_case", None)
 
         # File object that will be used to write sequence data
         fh = None
@@ -6284,6 +6285,10 @@ class AlignmentList(Base):
         c = 1
         
         for taxon, seq, aln_idx in self.iter_alignments(table_name):
+
+            # Convert sequence data to upper case if option is specified
+            if upper_case:
+                seq = seq.upper()
 
             if aln_idx != prev_file:
                 prev_file = aln_idx
@@ -6423,6 +6428,7 @@ class AlignmentList(Base):
         ns = kwargs.get("ns_pipe", None)
         pbar = kwargs.get("pbar", None)
         output_dir = kwargs.get("output_dir", None)
+        upper_case = kwargs.get("upper_case", None)
 
         # File object that will be used to write sequence data
         fh = None
@@ -6446,6 +6452,9 @@ class AlignmentList(Base):
             for taxon, seq, p, aln_idx in self.cur.execute(
                 "SELECT taxon, seq, slice, aln_idx from [.interleavedata] "
                 "ORDER BY aln_idx, slice"):
+                
+                if upper_case:
+                    seq = seq.upper()
 
                 if prev_file != aln_idx:
                     fh, of = self._setup_newfile(
@@ -6493,6 +6502,9 @@ class AlignmentList(Base):
             c = 1
 
             for taxon, seq, aln_idx in self.iter_alignments(table_name):
+                
+                if upper_case:
+                    seq = seq.upper()
 
                 if aln_idx != prev_file:
                     prev_file = aln_idx
@@ -6703,6 +6715,7 @@ class AlignmentList(Base):
         output_dir = kwargs.get("output_dir", None)
         ns = kwargs.get("ns_pipe", None)
         pbar = kwargs.get("pbar", None)
+        upper_case = kwargs.get("upper_case", None)
 
         # File object that will be used to write sequence data
         fh = None
@@ -6723,6 +6736,9 @@ class AlignmentList(Base):
                     "SELECT taxon, seq, slice, aln_idx "
                     "FROM [.interleavedata] "
                     "ORDER BY aln_idx, slice"):
+
+                if upper_case:
+                    seq = seq.upper()
 
                 if aln_idx != prev_file:
 
@@ -6777,6 +6793,9 @@ class AlignmentList(Base):
             c = 1
 
             for taxon, seq, aln_idx in self.iter_alignments(table_name):
+
+                if upper_case:
+                    seq = seq.upper()
 
                 if aln_idx != prev_file:
 
@@ -6922,6 +6941,7 @@ class AlignmentList(Base):
         ns = kwargs.get("ns_pipe", None)
         output_dir = kwargs.get("output_dir", None)
         pbar = kwargs.get("pbar", None)
+        upper_case = kwargs.get("upper_case", None)
 
         # File object that will be used to write sequence data
         fh = None
@@ -6933,6 +6953,9 @@ class AlignmentList(Base):
         c = 1
 
         for taxon, seq, aln_idx in self.iter_alignments(table_name):
+
+            if upper_case:
+                seq = seq.upper()
 
             if aln_idx != prev_file:
 
@@ -6963,6 +6986,7 @@ class AlignmentList(Base):
         ns = kwargs.get("ns_pipe", None)
         pbar = kwargs.get("pbar", None)
         output_dir = kwargs.get("output_dir", None)
+        upper_case = kwargs.get("upper_case", None)
 
         # File object that will be used to write sequence data
         fh = None
@@ -6984,6 +7008,9 @@ class AlignmentList(Base):
                 "SELECT taxon, seq, part_name, part, aln_idx "
                 "FROM [.partitiondata] "
                 "ORDER BY aln_idx, part"):
+
+            if upper_case:
+                seq = seq.upper()
 
             if prev_idx != aln_idx:
                 fh, of = self._setup_newfile(fh, aln_idx, output_dir,
@@ -7026,6 +7053,7 @@ class AlignmentList(Base):
         ns = kwargs.get("ns_pipe", None)
         pbar = kwargs.get("pbar", None)
         output_dir = kwargs.get("output_dir", None)
+        upper_case = kwargs.get("upper_case", None)
         
         population_file = ima2_params[0]
         population_tree = ima2_params[1]
@@ -7063,6 +7091,9 @@ class AlignmentList(Base):
                 "SELECT taxon, seq, part_name, part, aln_idx "
                 "FROM [.partitiondata] "
                 "ORDER BY aln_idx, part"):
+
+            if upper_case:
+                seq = seq.upper()
 
             if prev_idx != aln_idx:
                 fh, of = self._setup_newfile(fh, aln_idx, output_dir,
@@ -7116,6 +7147,7 @@ class AlignmentList(Base):
         ns = kwargs.get("ns_pipe", None)
         pbar = kwargs.get("pbar", None)
         output_dir = kwargs.get("output_dir", None)
+        upper_case = kwargs.get("upper_case", None)
 
         # File object that will be used to write sequence data
         fh = None
@@ -7137,6 +7169,9 @@ class AlignmentList(Base):
                 "SELECT taxon, seq, part_name, part, aln_idx "
                 "FROM [.partitiondata] "
                 "ORDER BY aln_idx, part"):
+            
+            if upper_case:
+                seq = seq.upper()
 
             if prev_idx != aln_idx:
                 fh, of = self._setup_newfile(fh, aln_idx, output_dir,
@@ -7242,6 +7277,9 @@ class AlignmentList(Base):
             A ProgressBar object used to log the progress of TriSeq execution.
         table_name : string
             Name of the table from where the sequence data is fetched.
+        upper_case : bool
+            If True, sequence data will be written in upper case. Default is
+            lower case
         """
 
         output_file = kwargs.pop("output_file", None)

--- a/trifusion/tests/test_process_write.py
+++ b/trifusion/tests/test_process_write.py
@@ -179,6 +179,37 @@ class ProcessWriteTest(unittest.TestCase):
                                    output_file=self.output_file,
                                    interleave=True)
 
+    def test_write_upper_case_phy(self):
+
+        self.aln_obj.write_to_file(["phylip"], output_file=self.output_file,
+                                   upper_case=True)
+
+        flag = True
+        with open(self.output_file + ".phy") as fh:
+            next(fh)
+            for line in fh:
+                seq = line.strip().split()[1]
+                if not seq.isupper():
+                    flag = False
+
+        self.assertTrue(flag, True)
+
+    def test_write_upper_case_fasta(self):
+
+        self.aln_obj.write_to_file(["fasta"], output_file=self.output_file,
+                                   upper_case=True)
+
+        flag = True
+        with open(self.output_file + ".fas") as fh:
+            for line in fh:
+                if line.startswith(">") or line.strip() == "":
+                    continue
+                else:
+                    if not line.strip().isupper():
+                        flag = False
+
+        self.assertTrue(flag, True)
+
     def test_write_gap(self):
 
         self.aln_obj.write_to_file(["fasta", "phylip", "nexus", "mcmctree",

--- a/trifusion/tests/test_stats.py
+++ b/trifusion/tests/test_stats.py
@@ -230,6 +230,12 @@ class SeconaryOpsTest(unittest.TestCase):
 
         self.assertTrue(self.aln_obj.characters_proportion_per_species())
 
+    def test_characters_proportion_gene(self):
+
+        self.assertTrue(self.aln_obj.characters_proportion_gene(
+            join(data_path, "BaseConc1.fas"), 10
+        ))
+
     def test_sequence_similarity(self):
 
         self.assertTrue(self.aln_obj.sequence_similarity())
@@ -242,6 +248,12 @@ class SeconaryOpsTest(unittest.TestCase):
 
         self.assertTrue(self.aln_obj.sequence_similarity_gene(
             join(data_path, "BaseConc1.fas"), 10))
+
+    def test_sequence_conservation(self):
+
+        self.assertTrue(self.aln_obj.sequence_conservation_gnp(
+            join(data_path, "BaseConc1.fas"), 10
+        ))
 
     def test_sequence_segregation(self):
 

--- a/trifusion/trifusion.kv
+++ b/trifusion/trifusion.kv
@@ -6079,7 +6079,23 @@
             DarkBox:
                 Label:
                     markup: True
-                    text: "[size=18][b]ZORRO weights support[/b][/size]\n[size=13]Concatenation only. Concatenates auxiliary Zorro weight files into a single *_zorro.out file."
+                    text: "[size=18][b]Sequence upper case[/b][/size]\n[size=13]Turn on to write sequence data as upper case (default is lower case)"
+                    halign: "left"
+                    valign: "middle"
+                    text_size: self.size
+                Switch:
+                    id: interleave
+                    size_hint_x: None
+                    width: root.process_bt_wdt
+                    on_active:
+                        app.update_process_switch("upper_case", self.active)
+
+            Hseparator
+
+            DarkBox:
+                Label:
+                    markup: True
+                    text: "[size=18][b]ZORRO weights support[/b][/size]\n[size=13]Concatenation only. Concatenates auxiliary Zorro weight files into a single *_zorro.out file"
                     halign: "left"
                     valign: "middle"
                     text_size: self.size
@@ -6160,7 +6176,7 @@
                 Label:
                     markup: True
                     id: test2
-                    text: "[size=18][b]Ignore missing data[/b][/size]\n[size=13] Sites containing missing data are removed before collapsing. This is effectively equivalent to setting filters to 0% of gap and missing data allowed. This may not be ideal for alignments with high proportion of missing data.[/size]"
+                    text: "[size=18][b]Ignore missing data[/b][/size]\n[size=13] Sites containing missing data are removed before collapsing. This is effectively equivalent to setting filters to 0% of gap and missing data allowed. This may not be ideal for alignments with high proportion of missing data[/size]"
                     halign: "left"
                     valign: "middle"
                     text_size: self.size


### PR DESCRIPTION
This PR adds the option to convert sequence data to upper case when writing output files in TriSeq/TriFusion. In TriSeq, this is done via the `-u` or `--uper-case` option. In TriFuson, the option is available in  `Process`  > `Show additional options` > `Formatting`.

Unit tests were also included to cover the new changes of the 1.0.1 version.